### PR TITLE
🔧 Put token auth first

### DIFF
--- a/backend/transcribee_backend/settings/base.py
+++ b/backend/transcribee_backend/settings/base.py
@@ -119,9 +119,9 @@ class Base(Configuration):
 
     REST_FRAMEWORK = {
         "DEFAULT_AUTHENTICATION_CLASSES": [
+            "rest_framework.authentication.TokenAuthentication",
             "rest_framework.authentication.BasicAuthentication",
             "rest_framework.authentication.SessionAuthentication",
-            "rest_framework.authentication.TokenAuthentication",
         ]
     }
 


### PR DESCRIPTION
Otherwise we get CRSF errors with a user is both logged in via session auth and provides a token