### PR TITLE
⬆️ Upgrade cache action to v3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,14 +23,14 @@ jobs:
           nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/43862987c3cf2554a542c6dd81f5f37435eb1423.tar.gz # keep in sync with shell.nix
 
       - name: Setup backend pypackages cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             backend/__pypackages__/
           key: ${{ runner.os }}-pypackages-${{ hashFiles('backend/pdm.lock') }}
 
       - name: Setup worker pypackages cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             worker/__pypackages__/


### PR DESCRIPTION
V2 uses node12, which GitHub deprecated and will be remove in september: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/