### PR TITLE
🐛 Move LazyDebugPanel out of blurred editor div

### DIFF
--- a/frontend/src/editor/transcription_editor.tsx
+++ b/frontend/src/editor/transcription_editor.tsx
@@ -143,9 +143,9 @@ export function TranscriptionEditor({ documentId }: { documentId: string }) {
             renderLeaf={renderLeaf}
           />
         </Slate>
-
-        <Suspense>{debugMode && <LazyDebugPanel editor={editor} value={value} />}</Suspense>
       </div>
+
+      <Suspense>{debugMode && <LazyDebugPanel editor={editor} value={value} />}</Suspense>
     </>
   );
 }


### PR DESCRIPTION
Fixes an issue where the debug bar was clipping to the top of the document while the editor state was loading