### PR TITLE
reduce information transmitted for list_tasks

### DIFF
--- a/backend/openapi-schema.yml
+++ b/backend/openapi-schema.yml
@@ -34,11 +34,10 @@ components:
           type: string
         dependencies:
           items:
-            $ref: '#/components/schemas/TaskResponse'
+            format: uuid
+            type: string
           title: Dependencies
           type: array
-        document:
-          $ref: '#/components/schemas/Document'
         document_id:
           format: uuid
           title: Document Id
@@ -67,7 +66,6 @@ components:
       - task_parameters
       - document_id
       - id
-      - document
       - is_completed
       - dependencies
       - assigned_worker
@@ -229,11 +227,10 @@ components:
           type: string
         dependencies:
           items:
-            $ref: '#/components/schemas/TaskResponse'
+            format: uuid
+            type: string
           title: Dependencies
           type: array
-        document:
-          $ref: '#/components/schemas/Document'
         document_id:
           format: uuid
           title: Document Id
@@ -258,7 +255,6 @@ components:
       - task_parameters
       - document_id
       - id
-      - document
       - is_completed
       - dependencies
       title: TaskResponse

--- a/backend/transcribee_backend/models/task.py
+++ b/backend/transcribee_backend/models/task.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Literal, Optional
 
 from sqlmodel import JSON, Column, Field, ForeignKey, Relationship, SQLModel
 from sqlmodel.sql.sqltypes import GUID
-from transcribee_proto.api import Document as ApiDocument
 from transcribee_proto.api import TaskType
 from typing_extensions import Self
 
@@ -85,20 +84,18 @@ class Task(TaskBase, table=True):
 
 class TaskResponse(TaskBase):
     id: uuid.UUID
-    document: ApiDocument
     progress: Optional[float]
     is_completed: bool
     completed_at: Optional[datetime.datetime] = None
     assigned_at: Optional[datetime.datetime] = None
-    dependencies: List["TaskResponse"]
+    dependencies: List[uuid.UUID]
 
     @classmethod
     def from_orm(cls, task: Task) -> Self:
         return super().from_orm(
             task,
             update={
-                "document": task.document.as_api_document(),
-                "dependencies": [TaskResponse.from_orm(x) for x in task.dependencies],
+                "dependencies": [x.id for x in task.dependencies],
             },
         )
 

--- a/frontend/src/editor/worker_status.tsx
+++ b/frontend/src/editor/worker_status.tsx
@@ -66,7 +66,7 @@ export function WorkerStatus({ documentId }: { documentId: string }) {
           return (
             <React.Fragment key={task.id}>
               {task?.dependencies?.map((dependency) => {
-                const dependencyIndex = data?.findIndex((task) => task?.id == dependency.id);
+                const dependencyIndex = data?.findIndex((task) => task?.id == dependency);
                 const dependencyY = yPositionsCircles[dependencyIndex];
 
                 const curvature = (i - dependencyIndex) * 10;
@@ -80,7 +80,7 @@ export function WorkerStatus({ documentId }: { documentId: string }) {
                 `;
                 return (
                   <path
-                    key={dependency.id}
+                    key={dependency}
                     d={path}
                     {...strokeProps}
                     stroke={getColor(data[dependencyIndex], systemPrefersDark)}

--- a/frontend/src/openapi-schema.ts
+++ b/frontend/src/openapi-schema.ts
@@ -103,8 +103,7 @@ export interface components {
        */
       completed_at?: string;
       /** Dependencies */
-      dependencies: (components["schemas"]["TaskResponse"])[];
-      document: components["schemas"]["Document"];
+      dependencies: (string)[];
       /**
        * Document Id
        * Format: uuid
@@ -226,8 +225,7 @@ export interface components {
        */
       completed_at?: string;
       /** Dependencies */
-      dependencies: (components["schemas"]["TaskResponse"])[];
-      document: components["schemas"]["Document"];
+      dependencies: (string)[];
       /**
        * Document Id
        * Format: uuid


### PR DESCRIPTION
Reduces the size of the answer by the backend by about 10x, and doesn't loose any information.

We could even consider reducing the data transmitted even more.