### PR TITLE
worker: discard unneeded websocket messages

### DIFF
--- a/worker/transcribee_worker/api_client.py
+++ b/worker/transcribee_worker/api_client.py
@@ -41,4 +41,8 @@ class ApiClient:
         async with websockets.connect(
             f"{self.websocket_base_url}{id}/?{params}"
         ) as websocket:
-            yield await SyncedDocument.create(websocket)
+            doc = await SyncedDocument.create(websocket)
+            try:
+                yield doc
+            finally:
+                doc.stop()


### PR DESCRIPTION
If not receiving the messages a internal buffer of the `websockets` library fills up and it stops responding to the `ping` messages of the backend, which in turn closes the connection.

Closes #214 for me for now