### PR TITLE
🐛 Fix type of document.speaker_names

### DIFF
--- a/proto/transcribee_proto/document.py
+++ b/proto/transcribee_proto/document.py
@@ -31,7 +31,7 @@ class Paragraph(BaseModel):
 
 
 class Document(BaseModel):
-    speaker_names: Optional[Mapping[int, str]]
+    speaker_names: Optional[Mapping[str, str]]
     children: List[Paragraph]
     version: int = 1
 


### PR DESCRIPTION
Fixes a crash in the worker: If the align task was started after a speaker name was assigned, pydantic refused to parse the document
