### PR TITLE
🐛 Simplify version banner

### DIFF
--- a/frontend/src/common/version.tsx
+++ b/frontend/src/common/version.tsx
@@ -36,7 +36,7 @@ export function CommitPopup({ commit, text }: { commit: Commit; text: string }) 
 }
 
 export function Version({ className = '' }: { className?: string }) {
-  const { lastCommitOnMain, branch, lastCommit, diffShort } = version;
+  const { lastCommit } = version;
 
   return (
     <div className={clsx('mb-10')}>
@@ -44,30 +44,23 @@ export function Version({ className = '' }: { className?: string }) {
         className={clsx(
           'absolute bottom-0 ',
           'h-10 text-xs',
-          'opacity-50 hover:opacity-100 duration-400 transition-all',
+          'opacity-70 hover:opacity-100 duration-400 transition-all',
           'w-full text-center',
           'left-1/2 -translate-x-1/2',
           className,
         )}
       >
-        Frontend built on {formatDate(version.date)}.{' '}
-        <CommitPopup
-          commit={lastCommitOnMain}
-          text={`${lastCommitOnMain.countSinceStart} commits on main`}
-        />
-        {branch != 'main' && (
-          <>
-            {' '}
-            +{' '}
-            <CommitPopup
-              commit={lastCommit}
-              text={`${
-                lastCommit.countSinceStart - lastCommitOnMain.countSinceStart
-              } commits on ${branch}`}
-            />
-          </>
-        )}
-        {diffShort && <> + {diffShort}</>}
+        Frontend built on {formatDate(version.date)}. Last commit{' '}
+        <a
+          href={`https://github.com/transcribee/transcribee/commit/${lastCommit.hash}`}
+          target="_blank"
+          rel="noreferrer"
+          className="underline decoration-dashed"
+          title="View commit on GitHub"
+        >
+          {lastCommit.hash.substring(0, 10)} <IoMdOpen className="inline" />
+        </a>{' '}
+        on {formatDate(lastCommit.date)}.
       </div>
     </div>
   );

--- a/frontend/src/common/virtual:git-version.d.ts
+++ b/frontend/src/common/virtual:git-version.d.ts
@@ -9,7 +9,6 @@ declare module 'virtual:git-version' {
     branch: string;
     diffShort: string;
     lastCommit: Commit;
-    lastCommitOnMain: Commit;
     date: string;
   }
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,7 +4,7 @@ import topLevelAwait from 'vite-plugin-top-level-await';
 import { execSync } from 'child_process';
 
 function gitVersionPlugin() {
-  const virtualModuleId = 'virtual:git-version'
+  const virtualModuleId = 'virtual:git-version';
 
   return {
     name: 'git-version', // required, will show up in warnings and errors
@@ -22,32 +22,30 @@ function gitVersionPlugin() {
           console.error(error);
         }
         return stdout;
-      };
+      }
 
       function commitInfo(ref) {
         return {
           hash: git(`rev-parse ${ref}`),
           date: git(`show -s --format=%cI ${ref}`),
           countSinceStart: parseInt(git(`rev-list --count ${ref}`)),
-        }
+        };
       }
 
       if (id === virtualModuleId) {
-        const lastCommitOnMain = git("merge-base origin/main HEAD");
         const json = JSON.stringify({
-          diffShort: git("diff --shortstat HEAD"),
-          lastCommit: commitInfo("HEAD"),
-          lastCommitOnMain: commitInfo(lastCommitOnMain),
-          branch: git("rev-parse --abbrev-ref HEAD"),
+          diffShort: git('diff --shortstat HEAD'),
+          lastCommit: commitInfo('HEAD'),
+          branch: git('rev-parse --abbrev-ref HEAD'),
           date: new Date().toISOString(),
-        })
+        });
         return `
           const version = ${json};
           export default version;
         `;
       }
     },
-  }
+  };
 }
 
 // eslint-disable-next-line import/no-default-export


### PR DESCRIPTION
The previous approach contained some assumptions that don't always hold in production deployments:
- full git history checked out
- a remote exists
- this remote is named "origin"
